### PR TITLE
Moose method modifier support

### DIFF
--- a/bin/countperl
+++ b/bin/countperl
@@ -87,6 +87,12 @@ sub parse_opts {
             pod2usage( -verbose => 2, -exitval => 1 );  # exits program
         }
 
+        if ( /--method-modifiers=(\S+)/ ) {
+            push @Perl::Metrics::Simple::Analysis::File::METHOD_MODIFIERS,
+                split /,/, $1;
+            next;
+        }
+
         push @FILES, $_;
     }
 
@@ -484,7 +490,7 @@ countperl - count lines, packages, subs and complexity of Perl files.
 
 =head1 USAGE
 
-B<countperl> F<FILE_OR_DIRECTORY> [F<FILE_OR_DIRECTORY> ....] [--html] [--help]
+B<countperl> F<FILE_OR_DIRECTORY> [F<FILE_OR_DIRECTORY> ...] [--html] [--help] [--method-modifiers=a,b,c]
 
 =head1 REQUIRED ARGUMENTS
 
@@ -501,6 +507,12 @@ Prints documentation to STDERR.
 =item --html
 
 Produces HTML output instead of the plain-text default.
+
+=item --method-modifiers=a,b,c
+
+A comma-separated list of method modifiers to be recognised, see
+L<Moose::Manual::MethodModifiers> for details. If unspecified, the
+default list is before,after,around.
 
 =back
 

--- a/lib/Perl/Metrics/Simple/Analysis/File.pm
+++ b/lib/Perl/Metrics/Simple/Analysis/File.pm
@@ -64,11 +64,19 @@ Readonly::Array our @DEFAULT_LOGIC_KEYWORDS => qw(
     until
     while
     );
+
+Readonly::Array our @DEFAULT_METHOD_MODIFIERS => qw(
+    before
+    after
+    around
+    );
+
+
 Readonly::Scalar my $LAST_CHARACTER => -1;
 
-our (@LOGIC_KEYWORDS, @LOGIC_OPERATORS); # For user-supplied values;
+our (@LOGIC_KEYWORDS, @LOGIC_OPERATORS, @METHOD_MODIFIERS); # For user-supplied values;
 
-our (%LOGIC_KEYWORDS, %LOGIC_OPERATORS); # Populated in _init()
+our (%LOGIC_KEYWORDS, %LOGIC_OPERATORS, %METHOD_MODIFIERS); # Populated in _init()
 
 # Private instance variables:
 my %_PATH       = ();
@@ -78,6 +86,7 @@ my %_PACKAGES   = ();
 my %_LINES      = ();
 my %_LOGIC_KEYWORDS = ();
 my %_LOGIC_OPERATORS = ();
+my %_METHOD_MODIFIERS = ();
 
 sub new {
     my ( $class, %parameters ) = @_;
@@ -106,14 +115,6 @@ sub _init {
         }
         $document = _create_ppi_document($path);
     }
-    $document = _make_pruned_document($document);
-
-    if ( !defined $document ) {
-        cluck "Could not make a PPI document from '$path'";
-        return;
-    }
-
-    my $packages = _get_packages($document);
 
     my @logic_keywords = @LOGIC_KEYWORDS  ? @LOGIC_KEYWORDS : @DEFAULT_LOGIC_KEYWORDS;
     %LOGIC_KEYWORDS = hashify(@logic_keywords);
@@ -122,6 +123,19 @@ sub _init {
     my @logic_operators = @LOGIC_OPERATORS ? @LOGIC_OPERATORS : @DEFAULT_LOGIC_OPERATORS;
     %LOGIC_OPERATORS = hashify(@logic_operators);
     $_LOGIC_OPERATORS{$self} = \%LOGIC_OPERATORS;
+
+    my @method_modifiers = @METHOD_MODIFIERS ? @METHOD_MODIFIERS : @DEFAULT_METHOD_MODIFIERS;
+    %METHOD_MODIFIERS = hashify(@method_modifiers);
+    $_METHOD_MODIFIERS{$self} = \%METHOD_MODIFIERS;
+
+    $document = $self->_make_pruned_document($document);
+
+    if ( !defined $document ) {
+        cluck "Could not make a PPI document from '$path'";
+        return;
+    }
+
+    my $packages = _get_packages($document);
 
     my @sub_analysis = ();
     my $sub_elements = $document->find('PPI::Statement::Sub');
@@ -156,9 +170,9 @@ sub _create_ppi_document {
 }
 
 sub _make_pruned_document {
-    my $document = shift;
+    my ($self, $document) = @_;
     $document = _prune_non_code_lines($document);
-    $document = _rewrite_moose_method_modifiers($document);
+    $document = $self->_rewrite_moose_method_modifiers($document);
     $document->index_locations();
     $document->readonly(1);
     return $document;
@@ -262,6 +276,11 @@ sub logic_operators {
     my ($self) = @_;
     return wantarray ? @{$_LOGIC_OPERATORS{$self}} : $_LOGIC_OPERATORS{$self};
 }
+
+sub method_modifiers {
+    my ($self) = @_;
+    return wantarray ? @{$_METHOD_MODIFIERS{$self}} : $_METHOD_MODIFIERS{$self};
+1}
 
 sub measure_complexity {
     my $self = shift;
@@ -376,11 +395,12 @@ sub _prune_non_code_lines {
 }
 
 sub _rewrite_moose_method_modifiers {
-    my $document = shift;
+    my ($self, $document) = @_;
     if ( !defined $document ) {
         Carp::confess('Did not supply a document!');
     }
 
+    my $re = '^(' . join('|', map {quotemeta} keys %{$_METHOD_MODIFIERS{$self}}) . ')$';
     my @method_modifiers =
         # 5th child: { ... }
         grep { $_->[5]->isa('PPI::Structure::Block') }
@@ -398,12 +418,13 @@ sub _rewrite_moose_method_modifiers {
         }
 
         # 2nd child: 'method_name'
-        grep { $_->[2]->isa('PPI::Token::Quote') }
+        grep { $_->[2]->isa('PPI::Token::Quote')
+            || $_->[2]->isa('PPI::Token::Word') }
 
         # 1st child: after
         grep {
                $_->[1]->isa('PPI::Token::Word')
-            && $_->[1]->content =~ /^(before|after|around)$/
+            && $_->[1]->content =~ /$re/
         }
 
         # create an arrayref [item, child0, child1, child2]
@@ -415,7 +436,7 @@ sub _rewrite_moose_method_modifiers {
 
     for (@method_modifiers) {
         my ($old_stmt, @children) = @$_;
-        my $name = '_' . $children[0]->literal . '_' . $children[1]->string;
+        my $name = '_' . $children[0]->literal . '_' . $children[1]->literal;
         my $new_stmt = PPI::Statement::Sub->new();
         $new_stmt->add_element(PPI::Token::Word->new('sub'));
         $new_stmt->add_element(PPI::Token::Whitespace->new(' '));
@@ -527,6 +548,11 @@ used in calculating complexity. See I<Logic Keywords> section below.
 Returns an array (in array context) or ref-to-ARRAY of the operators
 used in calculating complexity. See I<Logic Operators> section below.
 
+=head2 method_modifiers
+
+Returns an array (in array context) or ref-to-ARRAY of the method modifiers
+considered to return methods during calculating complexity. See I<Method modifiers> section below.
+
 =head2 measure_complexity
 
 Takes a B<PPI> element and measures an approximation of the
@@ -598,6 +624,17 @@ I<@Perl::Metrics::Simple::Analysis::File::DEFAULT_LOGIC_KEYWORDS>
 You can supply your own list by setting:
 I<@Perl::Metrics::Simple::Analysis::File::LOGIC_KEYWORDS> before creating a
 new object.
+
+=head3 Method modifiers:
+
+I<@Perl::Metrics::Simple::Analysis::File::DEFAULT_METHOD_MODIFIERS>
+
+    before
+    after
+    around
+
+You can supply your own list by setting:
+I<@Perl::Metrics::Simple::Analysis::File::METHOD_MODIFIERS> before creating a new object.
 
 =head3 Examples of Complexity
 

--- a/t/0020_find_files.t
+++ b/t/0020_find_files.t
@@ -44,6 +44,7 @@ sub test_find_files {
 
     my $expected_list = [
         "$TEST_DIRECTORY/Perl/Code/Analyze/Test/Module.pm",
+        "$TEST_DIRECTORY/Perl/Code/Analyze/Test/Moose.pm",
         "$TEST_DIRECTORY/empty_file.pl",
         "$TEST_DIRECTORY/no_packages_nor_subs",
         "$TEST_DIRECTORY/package_no_subs.pl",

--- a/t/0030_analyze.t
+++ b/t/0030_analyze.t
@@ -167,6 +167,7 @@ sub test_analyze_files {
     my $analysis = $analyzer->analyze_files($TEST_DIRECTORY);
     my @expected = (
         $test_data->{'Module.pm'},
+        $test_data->{'Moose.pm'},
         $test_data->{'empty_file.pl'},
         $test_data->{'no_packages_nor_subs'},
         $test_data->{'package_no_subs.pl'},
@@ -197,6 +198,7 @@ sub test_analysis {
 
     my @expected_files = (
         $test_data->{'Module.pm'}->{path},
+        $test_data->{'Moose.pm'}->{path},
         $test_data->{'empty_file.pl'}->{path},
         $test_data->{'no_packages_nor_subs'}->{path},
         $test_data->{'package_no_subs.pl'}->{path},
@@ -212,6 +214,7 @@ sub test_analysis {
     my @expected_packages = (
         'Perl::Metrics::Simple::Test::Module',
         'Perl::Metrics::Simple::Test::Module::InnerClass',
+        'Perl::Metrics::Simple::Test::Moose',
         'Hello::Dolly',
     );
     is_deeply( $analysis->packages, \@expected_packages,

--- a/t/0040_statistics.t
+++ b/t/0040_statistics.t
@@ -57,28 +57,28 @@ sub test_summary_stats {
     my $sub_length = $analysis->summary_stats->{sub_length};
     cmp_ok( $sub_length->{min},    '==', 1,   'minimum sub length.' );
     cmp_ok( $sub_length->{max},    '==', 9,   'maximum sub length.' );
-    cmp_ok( $sub_length->{mean},   '==', 5.2, 'mean (average) sub length.' );
-    cmp_ok( $sub_length->{median}, '==', 5,   'median sub length.' );
+    cmp_ok( $sub_length->{mean},   '==', 4.57, 'mean (average) sub length.' );
+    cmp_ok( $sub_length->{median}, '==', 3,   'median sub length.' );
     cmp_ok( $sub_length->{standard_deviation},
-        '==', 3.37, 'standard deviation of sub length.' );
+        '==', 3.02, 'standard deviation of sub length.' );
 
     my $sub_complexity = $analysis->summary_stats->{sub_complexity};
     cmp_ok( $sub_complexity->{min}, '==', 1, 'minimum sub complexity.' );
     cmp_ok( $sub_complexity->{max}, '==', 8, 'maximum sub complexity.' );
     cmp_ok( $sub_complexity->{mean},
-        '==', 3.2, 'mean (average) sub complexity.' );
+        '==', 2.57, 'mean (average) sub complexity.' );
     cmp_ok( $sub_complexity->{median}, '==', 1, 'median sub complexity.' );
     cmp_ok( $sub_complexity->{standard_deviation},
-        '==', 2.86, 'standard deviation of sub complexity.' );
+        '==', 2.61, 'standard deviation of sub complexity.' );
 
     my $main_complexity = $analysis->summary_stats->{main_complexity};
     cmp_ok( $main_complexity->{min}, '==', 0, 'minimum main complexity.' );
     cmp_ok( $main_complexity->{max}, '==', 3, 'maximum main complexity.' );
     cmp_ok( $main_complexity->{mean},
-        '==', 1.4, 'mean (average) main complexity.' );
+        '==', 1.33, 'mean (average) main complexity.' );
     cmp_ok( $main_complexity->{median}, '==', 1, 'median main complexity.' );
     cmp_ok( $main_complexity->{standard_deviation},
-        '==', 1.02, 'standard deviation of main complexity.' );
+        '==', 0.94, 'standard deviation of main complexity.' );
 
     return 1;
 }

--- a/t/lib/Perl/Metrics/Simple/TestData.pm
+++ b/t/lib/Perl/Metrics/Simple/TestData.pm
@@ -18,6 +18,7 @@ our $VERSION = '0.01';
 # Bad hack. Do this in the data instead!
 our @ORDER_OF_FILES = qw(
   Module.pm
+  Moose.pm
   empty_file.pl
   no_packages_nor_subs
   package_no_subs.pl
@@ -170,6 +171,33 @@ sub make_test_data {
             packages => [
                 'Perl::Metrics::Simple::Test::Module',
                 'Perl::Metrics::Simple::Test::Module::InnerClass'
+            ],
+        },
+        'Moose.pm' => {
+            path       => "$test_directory/Perl/Code/Analyze/Test/Moose.pm",
+            lines      => 9,
+            main_stats => {
+                lines             => 3,
+                mccabe_complexity => 1,
+                name              => '{code not in named subroutines}',
+                path => "$test_directory/Perl/Code/Analyze/Test/Moose.pm",
+            },
+            subs => [
+                {
+                    name              => 'foo',
+                    lines             => 3,
+                    mccabe_complexity => 1,
+                    path => "$test_directory/Perl/Code/Analyze/Test/Moose.pm",
+                },
+                {
+                    name              => '_after_bar',
+                    lines             => 3,
+                    mccabe_complexity => 1,
+                    path => "$test_directory/Perl/Code/Analyze/Test/Moose.pm",
+                },
+            ],
+            packages => [
+                'Perl::Metrics::Simple::Test::Moose',
             ],
         },
       },

--- a/t/test_files/Perl/Code/Analyze/Test/Moose.pm
+++ b/t/test_files/Perl/Code/Analyze/Test/Moose.pm
@@ -8,8 +8,8 @@ sub foo {
     return 42;
 }
 
-sub _after_bar {
+after 'bar' => sub {
     print 43;
-}
+};
 
 1;

--- a/t/test_files/Perl/Code/Analyze/Test/Moose.pm
+++ b/t/test_files/Perl/Code/Analyze/Test/Moose.pm
@@ -1,0 +1,15 @@
+# This is a comment. I love comments.
+
+package Perl::Metrics::Simple::Test::Moose;
+
+use Moose;
+
+sub foo {
+    return 42;
+}
+
+sub _after_bar {
+    print 43;
+}
+
+1;


### PR DESCRIPTION
Thanks to this year's Perl advent calendar article http://www.perladvent.org/2014/2014-12-08.html I stumbled upon Perl::Metrics::Simple, and immediately gave it a try on several projects' codebases. While the output was very useful in general, it fell short for projects making use of Moose. The cause for that is that all methods that use Moose's method modifiers look like normal statements to P:M:S, which sums them all up and reports them as "{code not in named subroutines}". While this is technically correct, I think we can do better here, by teaching P:M:S how Moose's method modifiers look like and treating them as normal methods.
In short, when applying my proposed patch, for a method declare as `around 'foo' => sub {...}`, P:M:S sees the code as equivalent to `sub _around_foo {...}`, and reports it as such.
If you see any issues regarding style or quality of the patch, please let me know!