### PR TITLE
Fix https://github.com/matisse/Perl-Metrics-Simple/issues/9

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for Perl module Perl::Metrics::Simple
 
+v1.0.1 - March 2021
+  Fix https://github.com/matisse/Perl-Metrics-Simple/issues/9
+    
+  - Add declaring required versions of modules wherever they are used
+    in addition to Build.PL and Makefile.PL
+  - Remove redundant compile testing of countperl.
+
 v1.0.0 - March 2021
   Declare dependency on Test::Compile v1.1.0 instead of 0, as v1.1.0
   is first version that documents the OO way of using Test::Compile.

--- a/META.json
+++ b/META.json
@@ -53,31 +53,31 @@
    "provides" : {
       "Perl::Metrics::Simple" : {
          "file" : "lib/Perl/Metrics/Simple.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       },
       "Perl::Metrics::Simple::Analysis" : {
          "file" : "lib/Perl/Metrics/Simple/Analysis.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       },
       "Perl::Metrics::Simple::Analysis::File" : {
          "file" : "lib/Perl/Metrics/Simple/Analysis/File.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       },
       "Perl::Metrics::Simple::Output" : {
          "file" : "lib/Perl/Metrics/Simple/Output.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       },
       "Perl::Metrics::Simple::Output::HTML" : {
          "file" : "lib/Perl/Metrics/Simple/Output/HTML.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       },
       "Perl::Metrics::Simple::Output::JSON" : {
          "file" : "lib/Perl/Metrics/Simple/Output/JSON.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       },
       "Perl::Metrics::Simple::Output::PlainText" : {
          "file" : "lib/Perl/Metrics/Simple/Output/PlainText.pm",
-         "version" : "v1.0.0"
+         "version" : "v1.0.1"
       }
    },
    "release_status" : "stable",
@@ -92,6 +92,6 @@
          "url" : "https://github.com/matisse/Perl-Metrics-Simple"
       }
    },
-   "version" : "v1.0.0",
+   "version" : "v1.0.1",
    "x_serialization_backend" : "JSON::PP version 4.06"
 }

--- a/META.yml
+++ b/META.yml
@@ -22,25 +22,25 @@ name: Perl-Metrics-Simple
 provides:
   Perl::Metrics::Simple:
     file: lib/Perl/Metrics/Simple.pm
-    version: v1.0.0
+    version: v1.0.1
   Perl::Metrics::Simple::Analysis:
     file: lib/Perl/Metrics/Simple/Analysis.pm
-    version: v1.0.0
+    version: v1.0.1
   Perl::Metrics::Simple::Analysis::File:
     file: lib/Perl/Metrics/Simple/Analysis/File.pm
-    version: v1.0.0
+    version: v1.0.1
   Perl::Metrics::Simple::Output:
     file: lib/Perl/Metrics/Simple/Output.pm
-    version: v1.0.0
+    version: v1.0.1
   Perl::Metrics::Simple::Output::HTML:
     file: lib/Perl/Metrics/Simple/Output/HTML.pm
-    version: v1.0.0
+    version: v1.0.1
   Perl::Metrics::Simple::Output::JSON:
     file: lib/Perl/Metrics/Simple/Output/JSON.pm
-    version: v1.0.0
+    version: v1.0.1
   Perl::Metrics::Simple::Output::PlainText:
     file: lib/Perl/Metrics/Simple/Output/PlainText.pm
-    version: v1.0.0
+    version: v1.0.1
 recommends:
   Readonly::XS: '1.02'
 requires:
@@ -60,5 +60,5 @@ resources:
   bugtracker: https://github.com/matisse/Perl-Metrics-Simple/issues
   license: http://dev.perl.org/licenses/
   repository: https://github.com/matisse/Perl-Metrics-Simple
-version: v1.0.0
+version: v1.0.1
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/bin/countperl
+++ b/bin/countperl
@@ -10,7 +10,7 @@ use Perl::Metrics::Simple::Output::JSON;
 use Perl::Metrics::Simple::Output::PlainText;
 use Pod::Usage qw(pod2usage);
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 exit main() if not caller;
 

--- a/lib/Perl/Metrics/Simple.pm
+++ b/lib/Perl/Metrics/Simple.pm
@@ -7,14 +7,14 @@ use Carp qw(cluck confess);
 use Data::Dumper;
 use English qw(-no_match_vars);
 use File::Basename qw(fileparse);
-use File::Find qw(find);
-use IO::File;
-use PPI;
+use File::Find 1.01 qw(find);
+use IO::File 1.14;
+use PPI 1.113;
 use Perl::Metrics::Simple::Analysis;
 use Perl::Metrics::Simple::Analysis::File;
-use Readonly;
+use Readonly 1.03;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 Readonly::Scalar our $PERL_FILE_SUFFIXES => qr{ \. (:? pl | pm | t ) }sxmi;
 Readonly::Scalar our $SKIP_LIST_REGEX    => qr{ \.svn | \. git | _darcs | CVS }sxmi;

--- a/lib/Perl/Metrics/Simple/Analysis.pm
+++ b/lib/Perl/Metrics/Simple/Analysis.pm
@@ -4,12 +4,12 @@ use warnings;
 
 use Carp qw(confess);
 use English qw(-no_match_vars);
-use Readonly;
+use Readonly 1.03;
 use Statistics::Basic::StdDev;
 use Statistics::Basic::Mean;
 use Statistics::Basic::Median;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 my %_ANALYSIS_DATA = ();
 my %_FILES         = ();

--- a/lib/Perl/Metrics/Simple/Analysis/File.pm
+++ b/lib/Perl/Metrics/Simple/Analysis/File.pm
@@ -6,11 +6,11 @@ use Carp qw(cluck confess);
 use Data::Dumper;
 use English qw(-no_match_vars);
 use Perl::Metrics::Simple::Analysis;
-use PPI;
+use PPI 1.113;
 use PPI::Document;
 use Readonly;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 Readonly::Scalar my $ALL_NEWLINES_REGEX =>
     qr/ ( \Q$INPUT_RECORD_SEPARATOR\E ) /sxm;

--- a/lib/Perl/Metrics/Simple/Output.pm
+++ b/lib/Perl/Metrics/Simple/Output.pm
@@ -1,6 +1,6 @@
 package Perl::Metrics::Simple::Output;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 use strict;
 use warnings;

--- a/lib/Perl/Metrics/Simple/Output/HTML.pm
+++ b/lib/Perl/Metrics/Simple/Output/HTML.pm
@@ -1,12 +1,12 @@
 package Perl::Metrics::Simple::Output::HTML;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 use strict;
 use warnings;
 
 use parent qw(Perl::Metrics::Simple::Output);
-use Readonly;
+use Readonly 1.03;
 
 Readonly my $EMPTY_STRING => q{};
 Readonly my $ONE_SPACE    => q{ };

--- a/lib/Perl/Metrics/Simple/Output/JSON.pm
+++ b/lib/Perl/Metrics/Simple/Output/JSON.pm
@@ -1,6 +1,6 @@
 package Perl::Metrics::Simple::Output::JSON;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 use strict;
 use warnings;

--- a/lib/Perl/Metrics/Simple/Output/PlainText.pm
+++ b/lib/Perl/Metrics/Simple/Output/PlainText.pm
@@ -1,13 +1,13 @@
 package Perl::Metrics::Simple::Output::PlainText;
 
-our $VERSION = 'v1.0.0';
+our $VERSION = 'v1.0.1';
 
 use strict;
 use warnings;
 
 use parent qw(Perl::Metrics::Simple::Output);
 
-use Readonly;
+use Readonly 1.03;
 
 Readonly my $MAX_PLAINTEXT_LABEL_LENGTH => 25;
 Readonly my $EMPTY_STRING               => q{};

--- a/t/000_compile.t
+++ b/t/000_compile.t
@@ -3,11 +3,10 @@
 use strict;
 use warnings;
 
-use Test::Compile;
+use Test::Compile v1.1.0;
 
 my $test = Test::Compile->new();
 
 $test->all_files_ok();
-pl_file_ok('bin/countperl');
 
 $test->done_testing();

--- a/t/0020_find_files.t
+++ b/t/0020_find_files.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use English qw(-no_match_vars);
 use FindBin qw($Bin);
-use Readonly;
+use Readonly 1.03;
 use Test::More tests => 6;
 
 Readonly::Scalar my $TEST_DIRECTORY => "$Bin/test_files";

--- a/t/0030_analyze.t
+++ b/t/0030_analyze.t
@@ -6,7 +6,7 @@ use File::Spec qw();
 use FindBin qw($Bin);
 use lib "$Bin/lib";
 use Perl::Metrics::Simple::TestData;
-use Readonly;
+use Readonly 1.03;
 use Test::More tests => 37;
 
 Readonly::Scalar my $TEST_DIRECTORY => "$Bin/test_files";

--- a/t/0040_statistics.t
+++ b/t/0040_statistics.t
@@ -5,7 +5,7 @@ use FindBin qw($Bin);
 use lib "$Bin/lib";
 use Perl::Metrics::Simple;
 use Perl::Metrics::Simple::TestData;
-use Readonly;
+use Readonly 1.03;
 use Test::More tests => 17;
 
 Readonly::Scalar my $TEST_DIRECTORY => "$Bin/test_files";

--- a/t/0050_file.t
+++ b/t/0050_file.t
@@ -4,9 +4,9 @@ use English qw(-no_match_vars);
 use Data::Dumper;
 use FindBin qw($Bin);
 use lib "$Bin/lib";
-use PPI;
+use PPI 1.113;
 use Perl::Metrics::Simple::Analysis::File;
-use Readonly;
+use Readonly 1.03;
 use Test::More tests => 20;
 
 Readonly::Scalar my $TEST_DIRECTORY => "$Bin/test_files";

--- a/t/lib/Perl/Metrics/Simple/TestData.pm
+++ b/t/lib/Perl/Metrics/Simple/TestData.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Carp qw(confess);
 use English qw(-no_match_vars);
-use Readonly;
+use Readonly 1.03;
 
 our $VERSION = '0.01';
 


### PR DESCRIPTION
- Add declaring required versions of modules wherever they are used
  in addition to Build.PL and Makefile.PL

- Remove redundant compile testing of countperl.