### PR TITLE
Fix/rewrite moose method modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.bak
 Build
 MYMETA.*
+Makefile
 Perl-Metrics-Simple-*
 _build
 blib

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl module Perl::Metrics::Simple
 
-v1.0.2 - November 2022
+v1.0.2 - January 2023
   Fix https://github.com/matisse/Perl-Metrics-Simple/issues/12
 
   - Change `_rewrite_moose_method_modifiers` in

--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Revision history for Perl module Perl::Metrics::Simple
 
+v1.0.2 - November 2022
+  Fix https://github.com/matisse/Perl-Metrics-Simple/issues/12
+
+  - Change `_rewrite_moose_method_modifiers` in
+    `Perl/Metrics/Simple/Analysis/File.pm` to check if a node supports the
+    `literal` method and use `string` instead if it does not.
+    Changes based on contribution by https://github.com/jwrightecs
+
 v1.0.1 - March 2021
   Fix https://github.com/matisse/Perl-Metrics-Simple/issues/9
     

--- a/MANIFEST
+++ b/MANIFEST
@@ -27,6 +27,7 @@ t/0100_output.t
 t/0100_output_html.t
 t/0100_output_json.t
 t/0100_output_plain.t
+t/0200_method_modifiers.t
 t/0901_pod.t
 t/0902_pod_coverage.t
 t/lib/Perl/Metrics/Simple/TestData.pm

--- a/META.json
+++ b/META.json
@@ -53,31 +53,31 @@
    "provides" : {
       "Perl::Metrics::Simple" : {
          "file" : "lib/Perl/Metrics/Simple.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       },
       "Perl::Metrics::Simple::Analysis" : {
          "file" : "lib/Perl/Metrics/Simple/Analysis.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       },
       "Perl::Metrics::Simple::Analysis::File" : {
          "file" : "lib/Perl/Metrics/Simple/Analysis/File.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       },
       "Perl::Metrics::Simple::Output" : {
          "file" : "lib/Perl/Metrics/Simple/Output.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       },
       "Perl::Metrics::Simple::Output::HTML" : {
          "file" : "lib/Perl/Metrics/Simple/Output/HTML.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       },
       "Perl::Metrics::Simple::Output::JSON" : {
          "file" : "lib/Perl/Metrics/Simple/Output/JSON.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       },
       "Perl::Metrics::Simple::Output::PlainText" : {
          "file" : "lib/Perl/Metrics/Simple/Output/PlainText.pm",
-         "version" : "v1.0.1"
+         "version" : "v1.0.2"
       }
    },
    "release_status" : "stable",
@@ -92,6 +92,6 @@
          "url" : "https://github.com/matisse/Perl-Metrics-Simple"
       }
    },
-   "version" : "v1.0.1",
-   "x_serialization_backend" : "JSON::PP version 4.06"
+   "version" : "v1.0.2",
+   "x_serialization_backend" : "JSON::PP version 4.12"
 }

--- a/META.yml
+++ b/META.yml
@@ -22,25 +22,25 @@ name: Perl-Metrics-Simple
 provides:
   Perl::Metrics::Simple:
     file: lib/Perl/Metrics/Simple.pm
-    version: v1.0.1
+    version: v1.0.2
   Perl::Metrics::Simple::Analysis:
     file: lib/Perl/Metrics/Simple/Analysis.pm
-    version: v1.0.1
+    version: v1.0.2
   Perl::Metrics::Simple::Analysis::File:
     file: lib/Perl/Metrics/Simple/Analysis/File.pm
-    version: v1.0.1
+    version: v1.0.2
   Perl::Metrics::Simple::Output:
     file: lib/Perl/Metrics/Simple/Output.pm
-    version: v1.0.1
+    version: v1.0.2
   Perl::Metrics::Simple::Output::HTML:
     file: lib/Perl/Metrics/Simple/Output/HTML.pm
-    version: v1.0.1
+    version: v1.0.2
   Perl::Metrics::Simple::Output::JSON:
     file: lib/Perl/Metrics/Simple/Output/JSON.pm
-    version: v1.0.1
+    version: v1.0.2
   Perl::Metrics::Simple::Output::PlainText:
     file: lib/Perl/Metrics/Simple/Output/PlainText.pm
-    version: v1.0.1
+    version: v1.0.2
 recommends:
   Readonly::XS: '1.02'
 requires:
@@ -60,5 +60,5 @@ resources:
   bugtracker: https://github.com/matisse/Perl-Metrics-Simple/issues
   license: http://dev.perl.org/licenses/
   repository: https://github.com/matisse/Perl-Metrics-Simple
-version: v1.0.1
+version: v1.0.2
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/bin/countperl
+++ b/bin/countperl
@@ -10,7 +10,7 @@ use Perl::Metrics::Simple::Output::JSON;
 use Perl::Metrics::Simple::Output::PlainText;
 use Pod::Usage qw(pod2usage);
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 exit main() if not caller;
 

--- a/lib/Perl/Metrics/Simple.pm
+++ b/lib/Perl/Metrics/Simple.pm
@@ -14,7 +14,7 @@ use Perl::Metrics::Simple::Analysis;
 use Perl::Metrics::Simple::Analysis::File;
 use Readonly 1.03;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 Readonly::Scalar our $PERL_FILE_SUFFIXES => qr{ \. (:? pl | pm | t ) }sxmi;
 Readonly::Scalar our $SKIP_LIST_REGEX    => qr{ \.svn | \. git | _darcs | CVS }sxmi;

--- a/lib/Perl/Metrics/Simple/Analysis.pm
+++ b/lib/Perl/Metrics/Simple/Analysis.pm
@@ -9,7 +9,7 @@ use Statistics::Basic::StdDev;
 use Statistics::Basic::Mean;
 use Statistics::Basic::Median;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 my %_ANALYSIS_DATA = ();
 my %_FILES         = ();

--- a/lib/Perl/Metrics/Simple/Analysis/File.pm
+++ b/lib/Perl/Metrics/Simple/Analysis/File.pm
@@ -10,7 +10,7 @@ use PPI 1.113;
 use PPI::Document;
 use Readonly;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 Readonly::Scalar my $ALL_NEWLINES_REGEX =>
     qr/ ( \Q$INPUT_RECORD_SEPARATOR\E ) /sxm;
@@ -429,7 +429,14 @@ sub _rewrite_moose_method_modifiers {
 
     for (@method_modifiers) {
         my ($old_stmt, @children) = @$_;
-        my $name = '_' . $children[0]->literal . '_' . $children[1]->literal;
+        my $name = '_' . $children[0]->literal . '_';
+        if ( $children[1]->can('literal') ) {
+            $name .= $children[1]->literal;
+        }
+        else {
+            my $string = $children[1]->string;
+            $name .= $string;
+        }
         my $new_stmt = PPI::Statement::Sub->new();
         $new_stmt->add_element(PPI::Token::Word->new('sub'));
         $new_stmt->add_element(PPI::Token::Whitespace->new(' '));

--- a/lib/Perl/Metrics/Simple/Output.pm
+++ b/lib/Perl/Metrics/Simple/Output.pm
@@ -1,6 +1,6 @@
 package Perl::Metrics::Simple::Output;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 use strict;
 use warnings;

--- a/lib/Perl/Metrics/Simple/Output/HTML.pm
+++ b/lib/Perl/Metrics/Simple/Output/HTML.pm
@@ -1,6 +1,6 @@
 package Perl::Metrics::Simple::Output::HTML;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 use strict;
 use warnings;

--- a/lib/Perl/Metrics/Simple/Output/JSON.pm
+++ b/lib/Perl/Metrics/Simple/Output/JSON.pm
@@ -1,6 +1,6 @@
 package Perl::Metrics::Simple::Output::JSON;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 use strict;
 use warnings;

--- a/lib/Perl/Metrics/Simple/Output/PlainText.pm
+++ b/lib/Perl/Metrics/Simple/Output/PlainText.pm
@@ -1,6 +1,6 @@
 package Perl::Metrics::Simple::Output::PlainText;
 
-our $VERSION = 'v1.0.1';
+our $VERSION = 'v1.0.2';
 
 use strict;
 use warnings;

--- a/t/0200_method_modifiers.t
+++ b/t/0200_method_modifiers.t
@@ -1,17 +1,16 @@
 #!/usr/bin/perl
 
+# Created for https://github.com/matisse/Perl-Metrics-Simple/issues/12
+
 use strict;
 use warnings;
 
+use English qw(-no_match_vars);
 use FindBin qw($Bin);
 use lib "$Bin/../lib";
 use Perl::Metrics::Simple;
 
 use Test::More tests => 5;
-
-my $CLASS_TO_TEST = 'Perl::Metrics::Simple::Output';
-
-use_ok($CLASS_TO_TEST);
 
 test_modifier( after => q{foo} );
 
@@ -19,22 +18,23 @@ test_modifier( after => q{'foo'} );
 
 test_modifier( after => q{"foo"} );
 
-test_modifier( after => q< qq[foo] >);
+test_modifier( after => q< qq[foo] > );
+
+test_modifier( after => q{some::package::foo} );
 
 exit;
 
 sub test_modifier {
-	my ( $modifier, $modificand ) = @_;
-	my $code = qq[
+    my ( $modifier, $modificand ) = @_;
+    my $code = qq[
 		$modifier $modificand => sub {
 			return "modified";
 		};
 	];
-	diag $code;
-	my $analyzer = Perl::Metrics::Simple->new;
-	my $analysis = eval { $analyzer->analyze_files( \$code ) } or diag $@;
-	isa_ok( $analysis, 'Perl::Metrics::Simple::Analysis' );
+
+    # diag $code;
+    my $analyzer = Perl::Metrics::Simple->new;
+    my $analysis = eval { $analyzer->analyze_files( \$code ) } or diag $EVAL_ERROR;
+    isa_ok( $analysis, 'Perl::Metrics::Simple::Analysis' );
 }
-
-
 

--- a/t/0200_method_modifiers.t
+++ b/t/0200_method_modifiers.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use FindBin qw($Bin);
+use lib "$Bin/../lib";
+use Perl::Metrics::Simple;
+
+use Test::More tests => 5;
+
+my $CLASS_TO_TEST = 'Perl::Metrics::Simple::Output';
+
+use_ok($CLASS_TO_TEST);
+
+test_modifier( after => q{foo} );
+
+test_modifier( after => q{'foo'} );
+
+test_modifier( after => q{"foo"} );
+
+test_modifier( after => q< qq[foo] >);
+
+exit;
+
+sub test_modifier {
+	my ( $modifier, $modificand ) = @_;
+	my $code = qq[
+		$modifier $modificand => sub {
+			return "modified";
+		};
+	];
+	diag $code;
+	my $analyzer = Perl::Metrics::Simple->new;
+	my $analysis = eval { $analyzer->analyze_files( \$code ) } or diag $@;
+	isa_ok( $analysis, 'Perl::Metrics::Simple::Analysis' );
+}
+
+
+

--- a/t/perlcritic.t
+++ b/t/perlcritic.t
@@ -16,9 +16,16 @@ if ($EVAL_ERROR) {
     plan( skip_all => $msg );
 }
 
+eval { require Perl::Critic::Utils; };
+
+if ($EVAL_ERROR) {
+    my $msg = 'Perl::Critic::Utils required for this test';
+    plan( skip_all => $msg );
+}
+
 my $rcfile = File::Spec->catfile( 't', 'perlcriticrc' );
 Test::Perl::Critic->import( -profile => $rcfile );
 
-my @perl_files = Test::Perl::Critic::all_code_files();
+my @perl_files = Perl::Critic::Utils::all_perl_files();
 all_critic_ok( @perl_files );
 


### PR DESCRIPTION
Fix https://github.com/matisse/Perl-Metrics-Simple/issues/12

- Change `_rewrite_moose_method_modifiers` in  `Perl/Metrics/Simple/Analysis/File.pm` to check if a node supports the `literal` method and use `string` instead if it does not.

Changes based on contribution by https://github.com/jwrightecs