### PR TITLE
Fix/rewrite moose method modifiers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl module Perl::Metrics::Simple
 
-v1.0.2 - November 2022
+v1.0.2 - July 2023
   Fix https://github.com/matisse/Perl-Metrics-Simple/issues/12
 
   - Change `_rewrite_moose_method_modifiers` in

--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ v1.0.2 - July 2023
     `literal` method and use `string` instead if it does not.
     Changes based on contribution by https://github.com/jwrightecs
 
+  - Fix typos in File.pm (thank you Florian Schlichting, fschlich)
+
 v1.0.1 - March 2021
   Fix https://github.com/matisse/Perl-Metrics-Simple/issues/9
     

--- a/META.json
+++ b/META.json
@@ -93,5 +93,5 @@
       }
    },
    "version" : "v1.0.2",
-   "x_serialization_backend" : "JSON::PP version 4.12"
+   "x_serialization_backend" : "JSON::PP version 4.02"
 }


### PR DESCRIPTION
  Fix https://github.com/matisse/Perl-Metrics-Simple/issues/12

  - Change `_rewrite_moose_method_modifiers` in
    `Perl/Metrics/Simple/Analysis/File.pm` to check if a node supports the
    `literal` method and use `string` instead if it does not.
    Changes based on contribution by https://github.com/jwrightecs

  - Also fix typos in File.pm (thank you Florian Schlichting, fschlich)
