### PR TITLE
countperl has incorrect import statement `use perlmetricssimple qw(0.13)`

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl module Perl::Metrics::Simple
 
+v1.0.3 - August 2023
+  Fix https://github.com/matisse/Perl-Metrics-Simple/issues/16
+
+  - Change an import in `countperl` to use a version number literal.
+  - Fix various issues found by Test::Perl::Critic
+
 v1.0.2 - July 2023
   Fix https://github.com/matisse/Perl-Metrics-Simple/issues/12
 

--- a/META.json
+++ b/META.json
@@ -53,31 +53,31 @@
    "provides" : {
       "Perl::Metrics::Simple" : {
          "file" : "lib/Perl/Metrics/Simple.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       },
       "Perl::Metrics::Simple::Analysis" : {
          "file" : "lib/Perl/Metrics/Simple/Analysis.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       },
       "Perl::Metrics::Simple::Analysis::File" : {
          "file" : "lib/Perl/Metrics/Simple/Analysis/File.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       },
       "Perl::Metrics::Simple::Output" : {
          "file" : "lib/Perl/Metrics/Simple/Output.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       },
       "Perl::Metrics::Simple::Output::HTML" : {
          "file" : "lib/Perl/Metrics/Simple/Output/HTML.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       },
       "Perl::Metrics::Simple::Output::JSON" : {
          "file" : "lib/Perl/Metrics/Simple/Output/JSON.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       },
       "Perl::Metrics::Simple::Output::PlainText" : {
          "file" : "lib/Perl/Metrics/Simple/Output/PlainText.pm",
-         "version" : "v1.0.2"
+         "version" : "v1.0.3"
       }
    },
    "release_status" : "stable",
@@ -92,6 +92,6 @@
          "url" : "https://github.com/matisse/Perl-Metrics-Simple"
       }
    },
-   "version" : "v1.0.2",
+   "version" : "v1.0.3",
    "x_serialization_backend" : "JSON::PP version 4.02"
 }

--- a/META.yml
+++ b/META.yml
@@ -22,25 +22,25 @@ name: Perl-Metrics-Simple
 provides:
   Perl::Metrics::Simple:
     file: lib/Perl/Metrics/Simple.pm
-    version: v1.0.2
+    version: v1.0.3
   Perl::Metrics::Simple::Analysis:
     file: lib/Perl/Metrics/Simple/Analysis.pm
-    version: v1.0.2
+    version: v1.0.3
   Perl::Metrics::Simple::Analysis::File:
     file: lib/Perl/Metrics/Simple/Analysis/File.pm
-    version: v1.0.2
+    version: v1.0.3
   Perl::Metrics::Simple::Output:
     file: lib/Perl/Metrics/Simple/Output.pm
-    version: v1.0.2
+    version: v1.0.3
   Perl::Metrics::Simple::Output::HTML:
     file: lib/Perl/Metrics/Simple/Output/HTML.pm
-    version: v1.0.2
+    version: v1.0.3
   Perl::Metrics::Simple::Output::JSON:
     file: lib/Perl/Metrics/Simple/Output/JSON.pm
-    version: v1.0.2
+    version: v1.0.3
   Perl::Metrics::Simple::Output::PlainText:
     file: lib/Perl/Metrics/Simple/Output/PlainText.pm
-    version: v1.0.2
+    version: v1.0.3
 recommends:
   Readonly::XS: '1.02'
 requires:
@@ -60,5 +60,5 @@ resources:
   bugtracker: https://github.com/matisse/Perl-Metrics-Simple/issues
   license: http://dev.perl.org/licenses/
   repository: https://github.com/matisse/Perl-Metrics-Simple
-version: v1.0.2
+version: v1.0.3
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/bin/countperl
+++ b/bin/countperl
@@ -4,13 +4,13 @@ use strict;
 use warnings;
 
 use Getopt::Long;
-use Perl::Metrics::Simple qw(0.13);
+use Perl::Metrics::Simple 0.13;
 use Perl::Metrics::Simple::Output::HTML;
 use Perl::Metrics::Simple::Output::JSON;
 use Perl::Metrics::Simple::Output::PlainText;
 use Pod::Usage qw(pod2usage);
 
-our $VERSION = 'v1.0.2';
+our $VERSION = 'v1.0.3';
 
 exit main() if not caller;
 

--- a/bin/countperl
+++ b/bin/countperl
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Carp qw(croak);
 use Getopt::Long;
 use Perl::Metrics::Simple 0.13;
 use Perl::Metrics::Simple::Output::HTML;
@@ -25,22 +26,22 @@ sub main {
 
     if ( my $modifiers = $options->{'method-modifiers'} ) {
         push @Perl::Metrics::Simple::Analysis::File::METHOD_MODIFIERS,
-            split( /,/, $modifiers );
+            split /,/sxm, $modifiers;
     }
 
     my $analysis = Perl::Metrics::Simple->new()->analyze_files(@files);
 
     if ( $options->{'html'} ) {
         my $html = Perl::Metrics::Simple::Output::HTML->new($analysis);
-        print $html->make_report();
+        print $html->make_report() or croak 'Failed to print!';
     }
     elsif ( $options->{'json'} ) {
         my $json = Perl::Metrics::Simple::Output::JSON->new($analysis);
-        print $json->make_report();
+        print $json->make_report() or croak 'Failed to print!';
     }
     else {
         my $plain = Perl::Metrics::Simple::Output::PlainText->new($analysis);
-        print $plain->make_report();
+        print $plain->make_report() or croak 'Failed to print!';
     }
 
     return 0;

--- a/lib/Perl/Metrics/Simple.pm
+++ b/lib/Perl/Metrics/Simple.pm
@@ -14,10 +14,10 @@ use Perl::Metrics::Simple::Analysis;
 use Perl::Metrics::Simple::Analysis::File;
 use Readonly 1.03;
 
-our $VERSION = 'v1.0.2';
+our $VERSION = 'v1.0.3';
 
-Readonly::Scalar our $PERL_FILE_SUFFIXES => qr{ \. (:? pl | pm | t ) }sxmi;
-Readonly::Scalar our $SKIP_LIST_REGEX    => qr{ \.svn | \. git | _darcs | CVS }sxmi;
+Readonly::Scalar our $PERL_FILE_SUFFIXES => qr{ [.] (:? pl | pm | t ) }sxmi;
+Readonly::Scalar our $SKIP_LIST_REGEX    => qr{ [.]svn | [.]git | _darcs | CVS }sxmi;
 Readonly::Scalar my $PERL_SHEBANG_REGEX  => qr/ \A [#] ! .* perl /sxm;
 Readonly::Scalar my $DOT_FILE_REGEX      => qr/ \A [.] /sxm;
 
@@ -31,8 +31,8 @@ sub new {
 sub analyze_files {
     my ( $self, @dirs_and_files ) = @_;
     my @results = ();
-    my @objects = grep { ref $_ } @dirs_and_files;
-    @dirs_and_files = grep { not ref $_ } @dirs_and_files;
+    my @objects = grep { ref } @dirs_and_files;
+    @dirs_and_files = grep { not ref } @dirs_and_files;
     foreach my $file ( (scalar(@dirs_and_files)?@{ $self->find_files(@dirs_and_files) }:()),@objects ) {
         my $file_analysis =
           Perl::Metrics::Simple::Analysis::File->new( path => $file );

--- a/lib/Perl/Metrics/Simple/Analysis.pm
+++ b/lib/Perl/Metrics/Simple/Analysis.pm
@@ -9,7 +9,7 @@ use Statistics::Basic::StdDev;
 use Statistics::Basic::Mean;
 use Statistics::Basic::Median;
 
-our $VERSION = 'v1.0.2';
+our $VERSION = 'v1.0.3';
 
 my %_ANALYSIS_DATA = ();
 my %_FILES         = ();

--- a/lib/Perl/Metrics/Simple/Analysis/File.pm
+++ b/lib/Perl/Metrics/Simple/Analysis/File.pm
@@ -10,7 +10,7 @@ use PPI 1.113;
 use PPI::Document;
 use Readonly;
 
-our $VERSION = 'v1.0.2';
+our $VERSION = 'v1.0.3';
 
 Readonly::Scalar my $ALL_NEWLINES_REGEX =>
     qr/ ( \Q$INPUT_RECORD_SEPARATOR\E ) /sxm;
@@ -64,8 +64,15 @@ Readonly::Array our @DEFAULT_METHOD_MODIFIERS => qw(
     around
     );
 
-
 Readonly::Scalar my $LAST_CHARACTER => -1;
+
+Readonly::Scalar my $ONE_SPACE => q{ };
+
+Readonly::Scalar my $PPI_CHILD_INDEX_AFTER => 1;
+Readonly::Scalar my $PPI_CHILD_INDEX_METHOD_NAME => 2;
+Readonly::Scalar my $PPI_CHILD_INDEX_OPERATOR => 3;
+Readonly::Scalar my $PPI_CHILD_INDEX_SUBROUTINE => 4;
+Readonly::Scalar my $PPI_CHILD_INDEX_BLOCK => 5;
 
 our (@LOGIC_KEYWORDS, @LOGIC_OPERATORS, @METHOD_MODIFIERS); # For user-supplied values;
 
@@ -273,7 +280,7 @@ sub logic_operators {
 sub method_modifiers {
     my ($self) = @_;
     return wantarray ? @{$_METHOD_MODIFIERS{$self}} : $_METHOD_MODIFIERS{$self};
-1}
+}
 
 sub measure_complexity {
     my $self = shift;
@@ -393,31 +400,31 @@ sub _rewrite_moose_method_modifiers {
         Carp::confess('Did not supply a document!');
     }
 
-    my $re = '^(' . join('|', map {quotemeta} keys %{$_METHOD_MODIFIERS{$self}}) . ')$';
+    my $re = q{^(} . join(q{|}, map {quotemeta} keys %{$_METHOD_MODIFIERS{$self}}) . q{)$};
     my @method_modifiers =
         # 5th child: { ... }
-        grep { $_->[5]->isa('PPI::Structure::Block') }
+        grep { $_->[$PPI_CHILD_INDEX_BLOCK]->isa('PPI::Structure::Block') }
 
         # 4th child: sub
         grep {
-               $_->[4]->isa('PPI::Token::Word')
-            && $_->[4]->content eq 'sub'
+               $_->[$PPI_CHILD_INDEX_SUBROUTINE]->isa('PPI::Token::Word')
+            && $_->[$PPI_CHILD_INDEX_SUBROUTINE]->content eq 'sub'
         }
 
         # 3rd child: =>
         grep {
-               $_->[3]->isa('PPI::Token::Operator')
-            && $_->[3]->content eq '=>'
+               $_->[$PPI_CHILD_INDEX_OPERATOR]->isa('PPI::Token::Operator')
+            && $_->[$PPI_CHILD_INDEX_OPERATOR]->content eq '=>'
         }
 
         # 2nd child: 'method_name'
-        grep { $_->[2]->isa('PPI::Token::Quote')
-            || $_->[2]->isa('PPI::Token::Word') }
+        grep { $_->[$PPI_CHILD_INDEX_METHOD_NAME]->isa('PPI::Token::Quote')
+            || $_->[$PPI_CHILD_INDEX_METHOD_NAME]->isa('PPI::Token::Word') }
 
         # 1st child: after
         grep {
-               $_->[1]->isa('PPI::Token::Word')
-            && $_->[1]->content =~ /$re/
+               $_->[$PPI_CHILD_INDEX_AFTER]->isa('PPI::Token::Word')
+            && $_->[$PPI_CHILD_INDEX_AFTER]->content =~ /$re/smx
         }
 
         # create an arrayref [item, child0, child1, child2]
@@ -428,7 +435,7 @@ sub _rewrite_moose_method_modifiers {
         grep { $_->class eq 'PPI::Statement' } $document->schildren;
 
     for (@method_modifiers) {
-        my ($old_stmt, @children) = @$_;
+        my ($old_stmt, @children) = @{$_};
         my $name = '_' . $children[0]->literal . '_';
         if ( $children[1]->can('literal') ) {
             $name .= $children[1]->literal;
@@ -439,10 +446,10 @@ sub _rewrite_moose_method_modifiers {
         }
         my $new_stmt = PPI::Statement::Sub->new();
         $new_stmt->add_element(PPI::Token::Word->new('sub'));
-        $new_stmt->add_element(PPI::Token::Whitespace->new(' '));
+        $new_stmt->add_element(PPI::Token::Whitespace->new($ONE_SPACE));
         $new_stmt->add_element(PPI::Token::Word->new($name));
-        $new_stmt->add_element(PPI::Token::Whitespace->new(' '));
-        $new_stmt->add_element($children[4]->clone());
+        $new_stmt->add_element(PPI::Token::Whitespace->new($ONE_SPACE));
+        $new_stmt->add_element($children[$PPI_CHILD_INDEX_SUBROUTINE]->clone());
 
         $old_stmt->insert_after($new_stmt);
         $old_stmt->delete();

--- a/lib/Perl/Metrics/Simple/Output.pm
+++ b/lib/Perl/Metrics/Simple/Output.pm
@@ -1,11 +1,11 @@
 package Perl::Metrics::Simple::Output;
 
-our $VERSION = 'v1.0.2';
-
 use strict;
 use warnings;
 
 use Carp qw();
+
+our $VERSION = 'v1.0.3';
 
 sub new {
     my ( $class, $analysis ) = @_;
@@ -13,7 +13,7 @@ sub new {
     if ((! ref $analysis) && ($analysis->isa('Perl::Metrics::Simple::Analysis')) ) {
         Carp::confess('Did not pass a Perl::Metrics::Simple::Analysis object.');
     }
-    
+
     my $self = bless {
         _analysis => $analysis,
     }, $class;
@@ -37,7 +37,7 @@ sub make_list_of_subs {
 
     my @main_from_each_file
         = map { $_->{main_stats} } @{ $analysis->file_stats() };
-    my @sorted_all_subs = sort { $b->{'mccabe_complexity'} <=> $a->{'mccabe_complexity'} } ( @{ $analysis->subs() }, @main_from_each_file );
+    my @sorted_all_subs = reverse sort { $a->{'mccabe_complexity'} <=> $b->{'mccabe_complexity'} } ( @{ $analysis->subs() }, @main_from_each_file );
 
     return [ \@main_from_each_file, \@sorted_all_subs ];
 }

--- a/lib/Perl/Metrics/Simple/Output/HTML.pm
+++ b/lib/Perl/Metrics/Simple/Output/HTML.pm
@@ -1,12 +1,12 @@
 package Perl::Metrics::Simple::Output::HTML;
 
-our $VERSION = 'v1.0.2';
-
 use strict;
 use warnings;
 
 use parent qw(Perl::Metrics::Simple::Output);
 use Readonly 1.03;
+
+our $VERSION = 'v1.0.3';
 
 Readonly my $EMPTY_STRING => q{};
 Readonly my $ONE_SPACE    => q{ };
@@ -217,7 +217,7 @@ sub make_list_of_subs {
 
     my $list_of_subs = '<table><tr><th colspan="4">List of subroutines, with most complex at top</th></tr>' . '<tr><td class="w100">complexity</td><td>sub</td><td>path</td><td class="w100">size</td><tr>';
 
-    foreach my $sub (@$sorted_subs) {
+    foreach my $sub (@{$sorted_subs}) {
         $list_of_subs .= make_list_of_subs_tr($sub);
     }
 

--- a/lib/Perl/Metrics/Simple/Output/JSON.pm
+++ b/lib/Perl/Metrics/Simple/Output/JSON.pm
@@ -1,12 +1,12 @@
 package Perl::Metrics::Simple::Output::JSON;
 
-our $VERSION = 'v1.0.2';
-
 use strict;
 use warnings;
 
 use parent qw(Perl::Metrics::Simple::Output);
 use JSON::PP qw(encode_json);
+
+our $VERSION = 'v1.0.3';
 
 sub make_report {
     my ($self) = @_;
@@ -74,3 +74,4 @@ sub make_complexity_section {
     };
 }
 
+1;

--- a/lib/Perl/Metrics/Simple/Output/PlainText.pm
+++ b/lib/Perl/Metrics/Simple/Output/PlainText.pm
@@ -1,13 +1,13 @@
 package Perl::Metrics::Simple::Output::PlainText;
 
-our $VERSION = 'v1.0.2';
-
 use strict;
 use warnings;
 
 use parent qw(Perl::Metrics::Simple::Output);
 
 use Readonly 1.03;
+
+our $VERSION = 'v1.0.3';
 
 Readonly my $MAX_PLAINTEXT_LABEL_LENGTH => 25;
 Readonly my $EMPTY_STRING               => q{};
@@ -126,7 +126,7 @@ sub make_list_of_subs {
     $list_of_subs .= _make_column( 'size',       $column_widths->{lines} );
     $list_of_subs .= "\n";
 
-    foreach my $sub (@$sorted_all_subs) {
+    foreach my $sub (@{$sorted_all_subs}) {
         $list_of_subs .= _make_list_of_subs_line( $sub, $column_widths );
     }
 
@@ -160,7 +160,7 @@ sub _get_column_widths {
         lines             => 4,
     };
 
-    foreach my $sub (@$main_from_each_file) {
+    foreach my $sub (@{$main_from_each_file}) {
         foreach my $col ( 'mccabe_complexity', 'name', 'path', 'lines' ) {
             if ( length( $sub->{$col} ) > $column_widths->{$col} ) {
                 $column_widths->{$col} = length( $sub->{$col} );


### PR DESCRIPTION
In a `use MODULE VERSION;` line the VERSION argument cannot be an arbitrary expression.

See `perldoc -f use`